### PR TITLE
CLI linking, package manager basis, and comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = {version="0.11.11", features = ["json"]}
-serde = {version="1.0.144", features = ["derive"]}
+colored = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
 Owl is a CLI application to easily install ReCT packages from https://rps.rect.ml.
-Owl is designed after the Arch Linux package manager, pacman.
+Owl is inspired by Arch Linux package manager, pacman.
 Packages can be installed, removed, updated, and more!
 </p>
 
@@ -38,19 +38,36 @@ $ owl <flag> [argument]
 All the flags that Owl accepts are based on the pacmam package manager flags. 
 In the table below, some flags require an argument and use `example` instead of a package name.
 
-| name                                  |  Flag   |         Example          | Explanation                                                                                                                                                                                                 |
-|---------------------------------------|:-------:|:------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Update Packages                       | `-Syu`  |        `owl -Syu`        | Update all packages and package dependencies on the system. This will also update the internal package index cache.                                                                                         |
-| Install Package(s)                    |  `-S`   |     `owl -S example`     | Sync package with package database. This installs the package and allows it to be used in ReCT code. Multiple packages can be installed by separating each package with a space after the -S flag.          |
-| Remove Package(s)                     |  `-R`   |     `owl -R example`     | Removes package from package database and deletes package from package storage. Multiple packages can be removed by separating each package with a space after the -R flag.                                 |
-| Remove Package(s) and dependencies    |  `-Rs`  |    `owl -Rs example`     | Removes the package and it's dependencies from the database. Mutliple packages can be listed. Dependencies are only removed if they are not required by any other package.                                  |
-| Remove redundant dependencies         | `-Qdtq` |       `owl -Qdtq`        | Removes any packages that are installed as a dependency, but are not used as a dependency by any package on the system. This may be useful for freeing up space.                                            |
-| Search for package                    |  `-Ss`  |    `owl -Ss example`     | Search through package index for the given package. If found, package information will be shown in the console (including how to install the package), otherwise owl will inform you of it's non-existence. |
-| Search for already installed packages |  `-Qs`  |    `owl -Qs example`     | Search through local package index for the given package. The package must already be installed for the search to be successful. Upon finding the package, the package information will be displayed.       |
-| View dependencies of a package        | `-Qds`  |    `owl -Ds example`     | Shows a list of dependencies required by a given package. This works for both installed packages and packages on the RPS.                                                                                   |
-| View all installed dependencies       |  `-Qd`  |        `owl -Qd`         | Shows a list of all dependency packages installed on the system. This also tells you what packages are using each dependency.                                                                               |
-| View all installed packages           |  `-Q`   |        `owl -Qsq`        | Show a list of every package currently installed on the system as well as other useful information.                                                                                                         |
-| Install a local package               |  `-U`   | `owl -U path/to/package` | Opens a dialog to create a new package and install it onto the local package index. This will not upload the package to the RPS, but will allow the package to be used by any ReCT program system-wide.     |
+| name                               |  Flag  |         Example          | Explanation                                                                                                                                                                                                 |
+|------------------------------------|:------:|:------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Update Packages                    | `-Syu` |        `owl -Syu`        | Update all packages and package dependencies on the system. This will also update the internal package index cache.                                                                                         |
+| Install Package(s)                 |  `-S`  |     `owl -S example`     | Sync package with package database. This installs the package and allows it to be used in ReCT code. Multiple packages can be installed by separating each package with a space after the -S flag.          |
+| Remove Package(s)                  |  `-R`  |     `owl -R example`     | Removes package from package database and deletes package from package storage. Multiple packages can be removed by separating each package with a space after the -R flag.                                 |
+| Remove Package(s) and dependencies | `-Rd`  |    `owl -Rd example`     | Removes the package and it's dependencies from the database. Mutliple packages can be listed. Dependencies are only removed if they are not required by any other package.                                  |
+| Remove redundant dependencies      | `-Rrd` |        `owl -Rrd`        | Removes any packages that are installed as a dependency, but are not used as a dependency by any package on the system. This may be useful for freeing up space.                                            |
+| Search for package                 | `-Ss`  |    `owl -Ss example`     | Search through package index for the given package. If found, package information will be shown in the console (including how to install the package), otherwise owl will inform you of it's non-existence. |
+| View dependencies of a package     | `-Qds` |    `owl -Qds example`    | Shows a list of dependencies required by a given package. This works for both installed packages and packages on the RPS.                                                                                   |
+| View all installed dependencies    | `-Qd`  |        `owl -Qd`         | Shows a list of all dependency packages installed on the system. This also tells you what packages are using each dependency.                                                                               |
+| View all installed packages        |  `-Q`  |         `owl -Q`         | Show a list of every package currently installed on the system as well as other useful information.                                                                                                         |
+| Install a local package            |  `-U`  | `owl -U path/to/package` | Opens a dialog to create a new package and install it onto the local package index. This will not upload the package to the RPS, but will allow the package to be used by any ReCT program system-wide.     |
+| View package information           |  `-I`  |     `owl -I package`     | View basic package information such as author, version, and more.                                                                                                                                           |
+
+The shorthand version of these flags can be confusing and hard to learn.
+Owl also has alternatives to these shorthand flags that may be more appealing to you.
+
+| Flag   | Alternative |
+|--------|-------------|
+| `-Syu` | `update`    |
+| `-S`   | `get`       |
+| `-R`   | `remove`    |
+| `-Rd`  | `eliminate` |
+| `-Rrd` | `clean`     |
+| `-Ss`  | `search`    |
+| `-Qds` | `deps`      |
+| `-Qd`  | `deps`      |
+| `-Q`   | `packages`  |
+| `-U`   | `install`   |
+| `-I`   | `info`      |
 
 
 ## Contributing

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,11 +1,23 @@
+
+// Calls RPS API for information on the given package.
+// Internally, this makes a call to /api/lookup/{package}.
+// Which should return the package info.
 pub fn lookup(package: String) {
 
 }
 
+// Calls RPS API to download a compressed .zip of the package.
+// Internally, this makes a call to /api/download/{pacakge}.
+// It's important to know this function does not handle.
+// Placing the file or extracting it in anyway, only downloading the files.
 pub fn download(package: String) {
 
 }
 
+// Calls RPS API to fetch the online package index.
+// Internally, this makes a call to /api/list.
+// The package index is just a list of all the packages on RPS.
+// Owl keeps a local version of this index to reduce API calls.
 pub fn list() {
 
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,34 +1,83 @@
+use crate::package_manager;
+use colored::Colorize;
 
 pub struct Cli {
     pub flag: String,
     pub arguments: Vec<String>,
 }
 
-pub fn process_flags(cli: &Cli) {
-
-    // Check for -Syu
-    match cli.flag.as_str() {
-        "-Syu" => {
-            if cli.arguments.len() < 1 {
-                println!("Updating packages");
-            } else {
-                println!("Unexpected number of arguments for -Syu!")
-            }
-        }
-        "-h" | "--help" => {
-            if cli.arguments.len() < 1 {
-                println!("Help menu [WIP]");
-            } else {
-                println!("Unexpected number of arguments for --h!")
-            }
-        }
-        "-S" => {
-            println!("Install package!");
-        }
-        "-R" => {
-            println!("Remove package!");
-        }
-        _ => println!("Could not find pattern for {}", cli.flag)
+impl Cli {
+    pub fn new(flag: String, arguments: Vec<String>) -> Cli {
+        Cli { flag, arguments }
     }
 
+    pub fn process_flags(&self) {
+
+        println!(":: Processing flags...");
+
+        // Check for -Syu
+        match self.flag.as_str() {
+            "-Syu"|"update" => {
+                if self.arguments.len() < 1 {
+                    package_manager::update();
+                } else {
+                    package_manager::update();
+                    package_manager::sync(self.arguments.clone())
+                }
+            }
+            "-h"|"--help"|"help" => Cli::help(),
+            "-S"|"get" =>
+                if self.arguments.len() < 1 {
+                    Cli::about("CLI[process_flags]",
+                        format!("Flag \"{}\" requires an argument of <package>!", self.flag.trim().bold(), )
+                    );
+                } else { package_manager::sync(self.arguments.clone()) }
+
+            "-R"|"remove"|"rm" => package_manager::remove(self.arguments.clone()),
+            _ => Cli::abort(
+                "CLI[process_flags]",
+            format!("Could not process flag \"{}\" as it does not exist!",
+                    self.flag.trim().bold())
+            ),
+        }
+    }
+
+    pub fn help() {
+        let name = "<name>".bold();
+        println!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
+            {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
+            {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
+            {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            ":: Owl is a RPS CLI App!\n".bold(),
+            ":: You can add, remove, update, and search packages using Owl!\n\n",
+            "==>".bright_green()," Usage: owl <flag> [option]\n\n".bold(),
+            "[INFO]".yellow(), " Flags are always prefixed with a dash (-Syu for example)\n",
+            "[INFO]".yellow(), " Options are always packages you wish to add/remove/search\n\n",
+            ":: Example of possible flags\n",
+            "  ","update".magenta().underline(),"    |"," -Syu".magenta(),"             = Update Installed Packages\n".bold(),
+            "  ","get".blue().underline(),"       |"," -S".blue(),"    ",name,"     = Install a new package\n".bold(),
+            "  ","remove".red().underline(),"    |"," -R".red(),"    ",name,"     = Remove a package\n".bold(),
+            "  ","eliminate".red().underline()," |"," -Rs".red(),"   ",name,"     = Remove a package and its dependencies\n".bold(),
+            "  ","search".white().underline(),"    |"," -Ss".white(),"   ",name,"     = Search for a package\n".bold(),
+            "  ","deps".bright_red().underline(),"      |"," -Qds".bright_red(),"  ",name,"     = List dependencies of a package\n".bold(),
+            "  ","deps".bright_red().underline(),"      |"," -Qd".bright_red(),"         ","     = List all dependencies\n".bold(),
+            "  ","packages".cyan().underline(),"  |"," -Q".cyan(),"          ","     = List all packages\n".bold(),
+            "  ","install".bright_green().underline(),"   |"," -U".bright_green(),"    ",name,"     = Install local package\n".bold(),
+            "  ","info".green().underline(),"      |"," -I".green(),"    ",name,"     = Get information on a package\n\n".bold(),
+            "[INFO]".yellow()," For more information visit the GitHub:   ","https://github.com/hrszpuk/Owl\n".bright_blue().underline(),
+            "[INFO]".yellow()," Or join the ReCT Discord:   ","https://discord.gg/Ymm9xGxWZf".bright_blue().underline(),
+        );
+    }
+
+    pub fn abort(sector: &str, message: String) {
+        println!(
+            "{}{}{}{}{}",
+            ":: Issue raised in ",sector.purple(),"!\n",
+            "[ABORT] ".red(), message.bright_red(),
+        );
+        std::process::exit(0);
+    }
 }
+
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,23 +17,23 @@ impl Cli {
 
         // Check for -Syu
         match self.flag.as_str() {
-            "-Syu"|"update" => {
-                if self.arguments.len() < 1 {
-                    package_manager::update();
-                } else {
-                    package_manager::update();
-                    package_manager::sync(self.arguments.clone())
-                }
-            }
-            "-h"|"--help"|"help" => Cli::help(),
-            "-S"|"get" =>
-                if self.arguments.len() < 1 {
-                    Cli::about("CLI[process_flags]",
-                        format!("Flag \"{}\" requires an argument of <package>!", self.flag.trim().bold(), )
-                    );
-                } else { package_manager::sync(self.arguments.clone()) }
-
+            "-Syu"|"update" => package_manager::update(),
+            "-S"|"get" => package_manager::sync(self.arguments.clone()),
             "-R"|"remove"|"rm" => package_manager::remove(self.arguments.clone()),
+            "-Rd"|"eliminate" => package_manager::eliminate(self.arguments.clone()),
+            "-Rrd"|"clean" => package_manager::clean(),
+            "-Ss"|"search"|"find" => package_manager::search(self.arguments.clone()),
+            "-Q"|"packages" => package_manager::list_packages(),
+            "-Qd" => package_manager::list_dependencies(),
+            "-Qds" => package_manager::list_package_dependencies(self.arguments.clone()),
+            "deps" => if self.arguments.len() < 1 {
+                package_manager::list_dependencies();
+            } else {
+                package_manager::list_package_dependencies(self.arguments.clone());
+            }
+            "-U"|"install" => package_manager::local_install(self.arguments.clone()),
+            "-I"|"info" => package_manager::info(self.arguments.clone()),
+            "-h"|"--help"|"help" => Cli::help(),
             _ => Cli::abort(
                 "CLI[process_flags]",
             format!("Could not process flag \"{}\" as it does not exist!",
@@ -48,7 +48,8 @@ impl Cli {
             "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
             {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
             {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
-            {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+            {}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}\
+            {}{}{}{}{}{}{}{}",
             ":: Owl is a RPS CLI App!\n".bold(),
             ":: You can add, remove, update, and search packages using Owl!\n\n",
             "==>".bright_green()," Usage: owl <flag> [option]\n\n".bold(),
@@ -58,7 +59,8 @@ impl Cli {
             "  ","update".magenta().underline(),"    |"," -Syu".magenta(),"             = Update Installed Packages\n".bold(),
             "  ","get".blue().underline(),"       |"," -S".blue(),"    ",name,"     = Install a new package\n".bold(),
             "  ","remove".red().underline(),"    |"," -R".red(),"    ",name,"     = Remove a package\n".bold(),
-            "  ","eliminate".red().underline()," |"," -Rs".red(),"   ",name,"     = Remove a package and its dependencies\n".bold(),
+            "  ","eliminate".red().underline()," |"," -Rd".red(),"   ",name,"     = Remove a package and its dependencies\n".bold(),
+            "  ","clean".bright_cyan().underline()," |"," -Rrd".bright_cyan(),"   ",name,"     = Remove any redundant dependencies\n".bold(),
             "  ","search".white().underline(),"    |"," -Ss".white(),"   ",name,"     = Search for a package\n".bold(),
             "  ","deps".bright_red().underline(),"      |"," -Qds".bright_red(),"  ",name,"     = List dependencies of a package\n".bold(),
             "  ","deps".bright_red().underline(),"      |"," -Qd".bright_red(),"         ","     = List all dependencies\n".bold(),
@@ -72,8 +74,7 @@ impl Cli {
 
     pub fn abort(sector: &str, message: String) {
         println!(
-            "{}{}{}{}{}",
-            ":: Issue raised in ",sector.purple(),"!\n",
+            ":: Issue raised in {}!\n{}{}", sector.purple(),
             "[ABORT] ".red(), message.bright_red(),
         );
         std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,33 @@
+// Adding needed creates
 use std::env;
 use crate::cli::Cli;
 
+// Adding other rust modules to the program
 mod cli;
 mod package_manager;
 mod api;
 
 
 fn main() {
-
+    // Fetching command line arguments and showing the help message if only "owl" is used.
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         Cli::help();
         return;
     }
 
+    // Now we convert the arguments to a Cli struct
+    // owl get package1 package2 package3
+    //     ^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //    Flag         Arguments
     let cmd = Cli::new(
         args[1].clone(),
         args[2..].to_owned()
     );
 
-    cmd.process_flags();
+    // Now we process the flags, this checks the flag and then calls the
+    // corresponding functions in package_manager.rs
+    cmd.process_flags();  // See cli.rs for more details
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,25 @@
 use std::env;
+use crate::cli::Cli;
+
 mod cli;
+mod package_manager;
+mod api;
 
 
 fn main() {
+
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        println!("Help menu [WIP]");
+        Cli::help();
         return;
     }
 
-    let cmd = cli::Cli {
-        flag: args[1].clone(),
-        arguments: args[2..].to_owned(),
-    };
+    let cmd = Cli::new(
+        args[1].clone(),
+        args[2..].to_owned()
+    );
 
-    println!("Flag: {:?}", cmd.flag);
-    println!("Args: {:?}", cmd.arguments);
-
-    cli::process_flags(&cmd);
+    cmd.process_flags();
 }
 
 

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -1,44 +1,65 @@
 
+// Downloads a package, installs it, and adds it to the database.
+// Flag: -S | get
 pub fn sync(args: Vec<String>) {
 
 }
 
+// Updates the local package index, checks and updates outdated packages.
+// Flag: -Syu | update
 pub fn update() {
 
 }
 
+// Removes a package, deletes the files, and removes it from the database.
+// Flag: -R | remove | rm
 pub fn remove(args: Vec<String>) {
 
 }
 
+// Removes a package and it's dependencies (if the dependencies aren't used elsewhere).
+// Flag: -Rs | eliminate
 pub fn eliminate(args: Vec<String>) {
 
 }
 
+// Removes any unused dependencies, deletes the files, and removes it from the database.
+// Flag: -Rrd | clean
 pub fn clean() {
 
 }
 
+// Searches for packages, this only searches local package index (which could be out of date).
+// Flag: -Ss | search | find
 pub fn search(args: Vec<String>) {
 
 }
 
+// Lists all the installed packages, including author, version, description, etc.
+// Flag: -Q | packages | list
 pub fn list_packages() {
 
 }
 
+// Lists all the installed dependencies, including what packages require them.
+// Flag: -Qd | deps
 pub fn list_dependencies() {
 
 }
 
+// Lists all the dependencies of a package
 pub fn list_package_dependencies(args: Vec<String>) {
 
 }
 
+// Install a package locally by providing a path to the package
+// Flag: -U | install
 pub fn local_install(args: Vec<String>) {
 
 }
 
+// Show information about a package
+// Flag: -I | info
 pub fn info(args: Vec<String>) {
 
 }

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -1,0 +1,12 @@
+
+pub fn sync(args: Vec<String>) {
+
+}
+
+pub fn update() {
+
+}
+
+pub fn remove(args: Vec<String>) {
+
+}

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -10,3 +10,35 @@ pub fn update() {
 pub fn remove(args: Vec<String>) {
 
 }
+
+pub fn eliminate(args: Vec<String>) {
+
+}
+
+pub fn clean() {
+
+}
+
+pub fn search(args: Vec<String>) {
+
+}
+
+pub fn list_packages() {
+
+}
+
+pub fn list_dependencies() {
+
+}
+
+pub fn list_package_dependencies(args: Vec<String>) {
+
+}
+
+pub fn local_install(args: Vec<String>) {
+
+}
+
+pub fn info(args: Vec<String>) {
+
+}


### PR DESCRIPTION
## Added CLI linking
The CLI can now detect any and all flags. The CLI will call the corresponding package manager functions for the flags passed. Arguments are cloned and given to the package manager.

## Added improved code comments
Originally, the project was commented as much, now every file has detailed comments on how everything works. This includes functions that aren't completed yet.