### PR TITLE
Fxied misalignment in Cli::help() output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "Owl"
-version = "0.1.0"
+name = "owl"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ impl Cli {
             "  ","get".blue().underline(),"       |"," -S".blue(),"    ",name,"     = Install a new package\n".bold(),
             "  ","remove".red().underline(),"    |"," -R".red(),"    ",name,"     = Remove a package\n".bold(),
             "  ","eliminate".red().underline()," |"," -Rd".red(),"   ",name,"     = Remove a package and its dependencies\n".bold(),
-            "  ","clean".bright_cyan().underline()," |"," -Rrd".bright_cyan(),"   ",name,"     = Remove any redundant dependencies\n".bold(),
+            "  ","clean".bright_cyan().underline(),"     |"," -Rrd".bright_cyan(),"   ",name,"    = Remove any redundant dependencies\n".bold(),
             "  ","search".white().underline(),"    |"," -Ss".white(),"   ",name,"     = Search for a package\n".bold(),
             "  ","deps".bright_red().underline(),"      |"," -Qds".bright_red(),"  ",name,"     = List dependencies of a package\n".bold(),
             "  ","deps".bright_red().underline(),"      |"," -Qd".bright_red(),"         ","     = List all dependencies\n".bold(),


### PR DESCRIPTION
Some information in the output of Cli::help() was misaligned.
This has been fixed by adding in character to adjust the alignment.

Changelog:
- Fixed "clean" option alignment in Cli::help()
- Updated Cargo.toml