### PR TITLE
Package System API Wrapper functions 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 colored = "2.0.0"
+reqwest = {version = "0.11.11", features = ["blocking"]}
+error-chain = {version = "0.12.4"}
+serde = {version = "1.0.144", features = ["derive"]}
+serde_json = "1.0.85"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,16 +1,42 @@
+use std::fs::read_to_string;
+use error_chain::error_chain;
+use reqwest;
+use std::io::Read;
+use serde::Deserialize;
+
+error_chain! {
+    foreign_links {
+        Io(std::io::Error);
+        HttpRequest(reqwest::Error);
+    }
+}
 
 // Calls RPS API for information on the given package.
 // Internally, this makes a call to /api/lookup/{package}.
 // Which should return the package info.
-pub fn lookup(package: String) {
+pub fn lookup(package: &String) -> Result<Package> {
+    let mut res = reqwest::blocking::get(
+        format!("https://rps.rect.ml/api/lookup/{}", package.trim()),
+    )?;
+    let mut body = String::new();
+    res.read_to_string(&mut body)?;
 
+    let package: Package = serde_json::from_str(&*body)
+        .expect("JSON not formatted correctly!");
+
+    Ok(package)
 }
 
 // Calls RPS API to download a compressed .zip of the package.
-// Internally, this makes a call to /api/download/{pacakge}.
+// Internally, this makes a call to /api/download/{package}.
 // It's important to know this function does not handle.
 // Placing the file or extracting it in anyway, only downloading the files.
 pub fn download(package: String) {
+
+}
+
+// This directly downloads the package from the RPS file system.
+pub fn direct_download(link: String) {
 
 }
 
@@ -18,6 +44,65 @@ pub fn download(package: String) {
 // Internally, this makes a call to /api/list.
 // The package index is just a list of all the packages on RPS.
 // Owl keeps a local version of this index to reduce API calls.
-pub fn list() {
+pub fn list() -> Result<Vec<Package>>{
+    let mut res = reqwest::blocking::get("https://rps.rect.ml/api/list")?;
+    let mut body = String::new();
+    res.read_to_string(&mut body)?;
 
+    let list_packages: Vec<ListPackage> = serde_json::from_str(&*body)
+        .expect("JSON not formatted correctly!");
+
+    let mut packages: Vec<Package> = Vec::new();
+    for package in list_packages {
+        packages.push(Package::from(&package));
+    }
+
+    Ok(packages)
+}
+
+// Package struct stores all the necessary package information
+// This does not store HTMLDescription or LastDownload because they aren't needed
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Package {
+    #[serde(rename = "ID")]
+    id: i32,
+    package_name: String,
+    author: String,
+    description: String,
+    downloads: i32,
+    link: String,
+    version: String,
+}
+
+// This exists because the RPS API is so bad it can return two different types of json objects.
+// A /api/lookup/ will return Package shown above, but /api/list will return the struct shown below.
+// The structs have identical content but differ in order of objects, and naming.
+// When using list(), this format will be used and convert to Package internally.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListPackage {
+    #[serde(rename = "ID")]
+    id: i32,
+    package_name: String,
+    version: String,
+    author: String,
+    description: String,
+    downloads: i32,
+    direct_source: String,
+}
+
+// This function implemented the conversion from ListPackage to Package
+impl Package {
+    pub fn from(pkg: &ListPackage) -> Package {
+        Package {
+            id: pkg.id,
+            package_name: pkg.package_name.clone(),
+            author: pkg.author.clone(),
+            description: pkg.description.clone(),
+            downloads: pkg.downloads,
+            link: pkg.direct_source.clone(),
+            version: pkg.version.clone(),
+        }
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,8 @@
-use std::fs::read_to_string;
+use std::fs::{File, read_to_string};
 use error_chain::error_chain;
 use reqwest;
-use std::io::Read;
+use std::io::{Read, Write};
+use std::io::copy;
 use serde::Deserialize;
 
 error_chain! {
@@ -31,13 +32,27 @@ pub fn lookup(package: &String) -> Result<Package> {
 // Internally, this makes a call to /api/download/{package}.
 // It's important to know this function does not handle.
 // Placing the file or extracting it in anyway, only downloading the files.
-pub fn download(package: String) {
+pub fn download(package: &String, path: &String) -> Result<&mut File> {
+    let url = format!("https://rps.rect.ml/api/download/{}", package.trim());
+    let mut res = reqwest::blocking::get(url)?;
+    let mut file = File::create(path)?;
+    let mut content =  res.bytes()?;
 
+    file.write_all(&*content).expect("TODO: panic message");
+    Ok(&mut file)
 }
 
 // This directly downloads the package from the RPS file system.
-pub fn direct_download(link: String) {
+// This avoids the /api/download/{package} call and takes the file from the
+// RPS File System instead: rpsf.rect.ml/{package}
+pub fn direct_download(package: &String, path: &String) -> Result<&mut File> {
+    let url = format!("https://rpsf.rect.ml/{}", package);
+    let mut res = reqwest::blocking::get(url)?;
+    let mut file = File::create(path)?;
+    let mut content = res.bytes()?;
 
+    file.write_all(&*content).expect("ERROR MESSAGE");
+    Ok(&mut file)
 }
 
 // Calls RPS API to fetch the online package index.

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,27 +32,27 @@ pub fn lookup(package: &String) -> Result<Package> {
 // Internally, this makes a call to /api/download/{package}.
 // It's important to know this function does not handle.
 // Placing the file or extracting it in anyway, only downloading the files.
-pub fn download(package: &String, path: &String) -> Result<&mut File> {
+pub fn download(package: &String, path: &String) -> Result<File> {
     let url = format!("https://rps.rect.ml/api/download/{}", package.trim());
     let mut res = reqwest::blocking::get(url)?;
     let mut file = File::create(path)?;
     let mut content =  res.bytes()?;
 
     file.write_all(&*content).expect("TODO: panic message");
-    Ok(&mut file)
+    Ok(file)
 }
 
 // This directly downloads the package from the RPS file system.
 // This avoids the /api/download/{package} call and takes the file from the
 // RPS File System instead: rpsf.rect.ml/{package}
-pub fn direct_download(package: &String, path: &String) -> Result<&mut File> {
+pub fn direct_download(package: &String, path: &String) -> Result<File> {
     let url = format!("https://rpsf.rect.ml/{}", package);
     let mut res = reqwest::blocking::get(url)?;
     let mut file = File::create(path)?;
     let mut content = res.bytes()?;
 
     file.write_all(&*content).expect("ERROR MESSAGE");
-    Ok(&mut file)
+    Ok(file)
 }
 
 // Calls RPS API to fetch the online package index.

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -3,7 +3,7 @@ use crate::api;
 // Downloads a package, installs it, and adds it to the database.
 // Flag: -S | get
 pub fn sync(args: Vec<String>) {
-
+    api::download(&args[0], &args[1]).expect("TODO: panic message");
 }
 
 // Updates the local package index, checks and updates outdated packages.

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -1,3 +1,4 @@
+use crate::api;
 
 // Downloads a package, installs it, and adds it to the database.
 // Flag: -S | get
@@ -38,7 +39,7 @@ pub fn search(args: Vec<String>) {
 // Lists all the installed packages, including author, version, description, etc.
 // Flag: -Q | packages | list
 pub fn list_packages() {
-
+    api::list().expect("TODO");
 }
 
 // Lists all the installed dependencies, including what packages require them.
@@ -61,5 +62,5 @@ pub fn local_install(args: Vec<String>) {
 // Show information about a package
 // Flag: -I | info
 pub fn info(args: Vec<String>) {
-
+    api::lookup(&args[0]).expect("TODO: panic message");
 }


### PR DESCRIPTION
## Package System API
The RPS API is the following endpoints:
- `https://rps.rect.ml/api/download/{package}`
- `https://rps.rect.ml/api/lookup/{package}`
- `https://rps.rect.ml/api/list`

The wrapper functions serve to simplify code in the main package manager system by allowing the package manager to only need to call a function with the package name and download path.

The main functions this pull request adds:
- `download(package, path)` downloads a package named {package} to {path}.
- `lookup(package)` returns a Package struct of the requested file.
- `list()` returns a `Vec` of Package structs.
- `direct_download(package, path)` downloads the package (without making API calls).